### PR TITLE
Improve database access and autoload

### DIFF
--- a/admin/admins.php
+++ b/admin/admins.php
@@ -5,7 +5,8 @@ if (!isset($_SESSION['admin_id'])) {
     exit;
 }
 require_once '../app/config/params.php';
-$pdo = $connexion;
+use Core\Database;
+$pdo = Database::getConnection();
 
 // Handle Add Admin
 if (isset($_POST['add_admin'])) {

--- a/admin/areas.php
+++ b/admin/areas.php
@@ -5,7 +5,8 @@ if (!isset($_SESSION['admin_id'])) {
     exit;
 }
 require_once '../app/config/params.php';
-$pdo = $connexion;
+use Core\Database;
+$pdo = Database::getConnection();
 
 // Handle Add Area
 if (isset($_POST['add_area'])) {

--- a/admin/bookings.php
+++ b/admin/bookings.php
@@ -5,7 +5,8 @@ if (!isset($_SESSION['admin_id'])) {
     exit;
 }
 require_once '../app/config/params.php';
-$pdo = $connexion;
+use Core\Database;
+$pdo = Database::getConnection();
 
 // Handle Add Booking
 if (isset($_POST['add_booking'])) {

--- a/admin/contact.php
+++ b/admin/contact.php
@@ -5,7 +5,8 @@ if (!isset($_SESSION['admin_id'])) {
     exit;
 }
 require_once '../app/config/params.php';
-$pdo = $connexion;
+use Core\Database;
+$pdo = Database::getConnection();
 
 // Fetch all contact info
 $stmt = $pdo->query("SELECT * FROM contact_info ORDER BY id ASC");

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -4,8 +4,9 @@ if (!isset($_SESSION['admin_id'])) {
     header('Location: login.php');
     exit;
 }
-require_once '../app/config/params.php'; // This sets up $connexion
-$pdo = $connexion;
+require_once '../app/config/params.php';
+use Core\Database;
+$pdo = Database::getConnection();
 
 // Fetch stats
 $stats = [];

--- a/admin/login.php
+++ b/admin/login.php
@@ -8,7 +8,8 @@ if (isset($_SESSION['admin_id'])) {
 }
 
 require_once '../app/config/params.php';
-$pdo = $connexion;
+use Core\Database;
+$pdo = Database::getConnection();
 
 $error = '';
 

--- a/admin/profile.php
+++ b/admin/profile.php
@@ -1,7 +1,8 @@
 <?php
 require_once 'includes/auth.php';
 require_once '../app/config/params.php';
-$pdo = $connexion;
+use Core\Database;
+$pdo = Database::getConnection();
 
 // Get current admin data
 $stmt = $pdo->prepare("SELECT * FROM admins WHERE id = ?");

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -5,7 +5,8 @@ if (!isset($_SESSION['admin_id'])) {
     exit;
 }
 require_once '../app/config/params.php';
-$pdo = $connexion;
+use Core\Database;
+$pdo = Database::getConnection();
 
 // Handle Add Review
 if (isset($_POST['add_review'])) {

--- a/admin/services.php
+++ b/admin/services.php
@@ -5,7 +5,8 @@ if (!isset($_SESSION['admin_id'])) {
     exit;
 }
 require_once '../app/config/params.php';
-$pdo = $connexion;
+use Core\Database;
+$pdo = Database::getConnection();
 
 // Handle Add Service
 if (isset($_POST['add_service'])) {

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -5,7 +5,8 @@ if (!isset($_SESSION['admin_id'])) {
     exit;
 }
 require_once '../app/config/params.php';
-$pdo = $connexion;
+use Core\Database;
+$pdo = Database::getConnection();
 
 // Fetch all settings
 $stmt = $pdo->query("SELECT * FROM settings ORDER BY id ASC");

--- a/admin/staff.php
+++ b/admin/staff.php
@@ -5,7 +5,8 @@ if (!isset($_SESSION['admin_id'])) {
     exit;
 }
 require_once '../app/config/params.php';
-$pdo = $connexion;
+use Core\Database;
+$pdo = Database::getConnection();
 
 // Handle Add Staff Availability
 if (isset($_POST['add_staff'])) {

--- a/app/config/params.php
+++ b/app/config/params.php
@@ -19,18 +19,6 @@ define('BASE_URL', '/scrub');
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-global $connexion;
-try {
-    $connexion = new PDO(
-        "mysql:host=" . 'localhost' . ";dbname=" . 'scrubhub',
-        'root',
-        '',
-        [
-            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-            PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8mb4"
-        ]
-    );
-} catch (PDOException $e) {
-    die('Connection failed: ' . $e->getMessage());
-}
+// Ensure database connection is available for legacy includes
+require_once __DIR__ . '/../../core/Database.php';
+

--- a/app/models/Model.php
+++ b/app/models/Model.php
@@ -3,17 +3,14 @@
 namespace App\Models;
 
 use PDO;
+use Core\Database;
 
 abstract class Model {
     protected $connexion;
     protected $table;
 
     public function __construct() {
-        global $connexion;
-        if (!isset($connexion)) {
-            throw new \Exception('Database connection not initialized');
-        }
-        $this->connexion = $connexion;
+        $this->connexion = Database::getConnection();
     }
 
     public function findAll() {

--- a/app/routers/index.php
+++ b/app/routers/index.php
@@ -17,8 +17,6 @@ if (isset($_GET['page'])) {
     $uri = $_GET['page'];
 }
 
-global $connexion;
-
 try {
     switch ($uri) {
         case '':

--- a/app/views/pages/home.php
+++ b/app/views/pages/home.php
@@ -1,12 +1,20 @@
-<?php include_once __DIR__ . '/../components/_home-hero.php'; ?>
-<?php include_once __DIR__ . '/../components/_promo.php'; ?>
+<?php
+// Home page assembled from reusable components to create a rich landing page
 
-<script>
-    // Hide footer on home page
-    document.addEventListener('DOMContentLoaded', function() {
-        const footer = document.querySelector('footer');
-        if (footer) {
-            footer.style.display = 'none';
-        }
-    });
-</script> 
+include_once __DIR__ . '/../components/_home-hero.php';
+
+// Showcase our top services
+include_once __DIR__ . '/../components/_services.php';
+
+// Brief introduction about the business
+include_once __DIR__ . '/../components/_about.php';
+
+// Outline the simple booking process
+include_once __DIR__ . '/../components/_process.php';
+
+// Recent testimonials from satisfied customers
+include_once __DIR__ . '/../components/_testimonials.php';
+
+// Promotional banner for special offers
+include_once __DIR__ . '/../components/_promo.php';
+?>

--- a/core/Database.php
+++ b/core/Database.php
@@ -1,0 +1,35 @@
+<?php
+namespace Core;
+
+use PDO;
+use PDOException;
+
+class Database {
+    private static ?PDO $connection = null;
+
+    public static function getConnection(): PDO
+    {
+        if (self::$connection === null) {
+            $dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME;
+            try {
+                self::$connection = new PDO(
+                    $dsn,
+                    DB_USER,
+                    DB_PASS,
+                    [
+                        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                        PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4'
+                    ]
+                );
+            } catch (PDOException $e) {
+                die('Connection failed: ' . $e->getMessage());
+            }
+        }
+
+        return self::$connection;
+    }
+}
+
+// For legacy code that relies on $connexion
+$GLOBALS['connexion'] = Database::getConnection();

--- a/core/init.php
+++ b/core/init.php
@@ -2,15 +2,23 @@
 
 // Autoloader
 spl_autoload_register(function ($class) {
-    // Convert namespace to full file path
-    $class = str_replace('\\', DIRECTORY_SEPARATOR, $class);
-    $file = __DIR__ . '/../' . $class . '.php';
-    
-    // If the file exists, require it
+    // Convert namespace to a relative file path
+    $classPath = str_replace('\\', DIRECTORY_SEPARATOR, $class);
+    $baseDir   = __DIR__ . '/../';
+
+    // Try path with original case
+    $file = $baseDir . $classPath . '.php';
+    if (file_exists($file)) {
+        require_once $file;
+        return;
+    }
+
+    // Fallback for case-insensitive file systems
+    $file = $baseDir . strtolower($classPath) . '.php';
     if (file_exists($file)) {
         require_once $file;
     }
 });
 
 require_once __DIR__ . '/../app/config/params.php';
-require_once __DIR__ . '/../core/connexion.php';
+require_once __DIR__ . '/Database.php';

--- a/index.php
+++ b/index.php
@@ -21,4 +21,3 @@ require_once __DIR__ . '/app/routers/index.php';
 
 // Do NOT include the main template here unconditionally!
 
-global $pdo;


### PR DESCRIPTION
## Summary
- implement a `Core\Database` helper for PDO connection
- load the DB helper from global config
- make autoloader case-insensitive
- update models to use the helper
- clean up router
- expand the home page

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684155b1dd7c833085e0664ab652bbe8